### PR TITLE
Soundpath creation and helper files modifed

### DIFF
--- a/source/seqdiv.sv
+++ b/source/seqdiv.sv
@@ -80,7 +80,7 @@ module seqdiv
       next_C = C;
 
       next_start = 0;
-      next_dived = 1;
+      next_dived = 0;   //was 1
 
       Q_out = Q[7:0];
     end

--- a/source/soundpath.sv
+++ b/source/soundpath.sv
@@ -1,0 +1,45 @@
+// ************************************************************************************************
+// Soundpath module
+//   inputs: sample_now <- from sample clk divider to activate seqdiv
+//           mode <- off, sqare, saw, triangle
+//           divisor <- value from LUT to calculate period
+//           clk
+//           n_rst <- expects a ACTIVE LOW rst Signals
+//   output: sample <- 8 bit sample to be give to wave_comb and pwm
+//           done <- signals when value is ready to be read
+//
+//   Use: This is an integration module that groups together the oscilator, seqential divider, and
+//        waveshaper as they are always used together in a path.
+// ************************************************************************************************
+
+module soundpath(input logic clk, n_rst, sample_now,
+                 input logic [1:0] mode,
+                 input logic [18:0] divisor,
+                 output logic [7:0] sample,
+                 output logic done
+);
+
+  logic [7:0] Q; //quotient value before it is shaped by the waveshaper
+  logic [18:0] count; //counting up value from oscilator, serves as dividend
+  
+
+  oscilator osc (.clk(clk),
+                   .nrst(n_rst),
+                   .max(divisor),
+                   .count(count));
+
+  seqdiv sdiv (.clk(clk),
+               .RST(n_rst),
+               .sample(sample_now),
+               .count(count),
+               .dsor(divisor),
+               .done(done),
+               .Q_out(Q));
+
+  waveshaper waveshape (.Q(Q),
+                        .mode({1'b0, mode}),
+                        .count(count),
+                        .divisor(divisor),
+                        .sample(sample));
+
+endmodule

--- a/source/tb_soundpath.sv
+++ b/source/tb_soundpath.sv
@@ -1,0 +1,85 @@
+`default_nettype none
+
+`timescale 1ns/10ps
+
+module tb_soundpath();
+
+localparam CLK_PERIOD = 83.33; // 12 Mhz
+
+logic tb_checking_outputs = 1'b0; 
+integer tb_test_num;
+logic[1024:0] tb_test_case; 
+
+
+// TB Signals
+
+
+
+
+logic tb_clk;
+logic tb_Rst_i;
+logic [1:0] tb_mode;
+logic [18:0] tb_divisor;
+logic [7:0] tb_sample;
+logic tb_done;
+logic tb_sample_now;
+
+task reset_dut;
+    @(negedge tb_clk);
+    tb_Rst_i = 1'b0; 
+    @(negedge tb_clk); 
+    tb_Rst_i = 1'b1; 
+endtask
+
+always begin
+    tb_sample_now = 0;
+    #(CLK_PERIOD * 255);
+    tb_sample_now = 1;
+    #(CLK_PERIOD);
+end
+
+always begin
+    tb_clk = 1'b0; 
+    #(CLK_PERIOD / 2);
+    tb_clk = 1'b1; 
+    #(CLK_PERIOD / 2); 
+end
+
+
+ soundpath DUT (.clk(tb_clk),
+                 .n_rst(tb_Rst_i),
+                 .sample_now(tb_sample_now),
+                 .mode(tb_mode),
+                 .divisor(tb_divisor),
+                 .sample(tb_sample),
+                 .done(tb_done));
+
+initial begin
+
+    $dumpfile("dump.vcd");
+    $dumpvars; 
+
+    tb_mode = 2'd0;
+    tb_Rst_i = 1;
+    tb_divisor = 19'd2658;
+    
+    reset_dut();
+
+    #(CLK_PERIOD * (tb_divisor * 5));
+
+    tb_mode = 2'd1;
+    
+    #(CLK_PERIOD * (tb_divisor * 5));
+
+    tb_mode = 2'd2;
+    
+    #(CLK_PERIOD * (tb_divisor * 5));
+
+    tb_mode = 2'd3;
+    
+    #(CLK_PERIOD * (tb_divisor * 5));
+    
+    $finish; 
+end
+
+endmodule 

--- a/source/waveform_comb.sv
+++ b/source/waveform_comb.sv
@@ -13,7 +13,7 @@
 //    comb_waveform -> Final combined waveform value to be outputed to pwm
 /*************************************************************************************************************/
 
-module waveform_comb (input logic multi, done1, done2, clk, n_rst, input logic [7:0]sample1, sample2, output logic ready, output logic [7:0] comb_waveform);
+module waveform_comb (input logic multi, done1, done2, input logic [7:0]sample1, sample2, output logic ready, output logic [7:0] comb_waveform);
 
     logic [8:0] new_sample1, new_sample2, sum, inter_waveform; // Creating new varibales with one extra bit to handle overflow when adding
 


### PR DESCRIPTION
created an integration module named soundpath to group the oscilator, seqdiv, and waveshaper together as they are always used in a path. Seqdiv was changed to pulse done instead of keep on. Removed clk from waveform_comb as it is never used.